### PR TITLE
reversed line 2&3

### DIFF
--- a/model/init_db.sql
+++ b/model/init_db.sql
@@ -1,6 +1,7 @@
 DROP TABLE IF EXISTS `interactions`;
+DROP TABLE IF EXISTS `items`; 
 DROP TABLE IF EXISTS `users`;
-DROP TABLE IF EXISTS `items`;
+
 
 CREATE TABLE `users`(
     `id` INT NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
I had to switch these two lines in init_db.sql:
DROP TABLE IF EXISTS items;  
DROP TABLE IF EXISTS users;

items should be dropped first, then users cuz the original migration script is trying to drop the users table, but MySQL is preventing it because the items table has a foreign key constraint that references users.id. Since the items table depends on users, I had to drop items first before dropping users. With this change, I was able to run the migration successfully 